### PR TITLE
Fix multiple words search (now OR instead of AND)

### DIFF
--- a/dj_bookmarks/bookmarks/views.py
+++ b/dj_bookmarks/bookmarks/views.py
@@ -1,3 +1,6 @@
+import operator
+from functools import reduce
+
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
@@ -103,5 +106,5 @@ class Search(LoginRequiredMixin, generic.ListView):
             Q(title__icontains=word) | Q(description__icontains=word)
             for word in self.request.GET.get('q').split()
         ]
-        queryset = queryset.filter(*[q for q in q_objects])
+        queryset = queryset.filter(reduce(operator.or_, q_objects))
         return queryset


### PR DESCRIPTION
References #16 

Resulting query

> _SELECT ••• FROM "bookmarks_bookmark" WHERE ("bookmarks_bookmark"."user_id" = '1' AND "bookmarks_bookmark"."deleted_at" IS NULL AND ("bookmarks_bookmark"."title" LIKE '''%treehouse%''' ESCAPE '\' OR "bookmarks_bookmark"."description" LIKE '''%treehouse%''' ESCAPE '\'_ **OR** _"bookmarks_bookmark"."title" LIKE '''%free%''' ESCAPE '\' OR "bookmarks_bookmark"."description" LIKE '''%free%''' ESCAPE '\'))_

[Dynamic querying related article](https://micropyramid.com/blog/querying-with-django-q-objects/) from where i've learned this method